### PR TITLE
Rework Hashicorp DSL

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -11,6 +11,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
+apply plugin: 'java-test-fixtures'
+
 dependencies {
 
   testRuntimeOnly 'javax.activation:activation'
@@ -30,6 +32,17 @@ dependencies {
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.apache.tuweni:tuweni-net'
   testImplementation(testFixtures(project(":keystorage:hashicorp")))
+  testImplementation sourceSets.testFixtures.output
+
+  testFixturesImplementation 'com.github.docker-java:docker-java'
+  testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
+  testFixturesImplementation 'org.apache.logging.log4j:log4j-slf4j-impl'
+  testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
+  testFixturesImplementation 'org.assertj:assertj-core'
+  testFixturesImplementation 'org.awaitility:awaitility'
+  testFixturesImplementation 'org.apache.tuweni:tuweni-net'
+  testFixturesImplementation 'org.junit.jupiter:junit-jupiter-engine'
+  testFixturesImplementation 'org.bouncycastle:bcpkix-jdk15on'
 }
 
 test.enabled = false

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/keystorage/hashicorp/tests/HashicorpVaultAccessAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/keystorage/hashicorp/tests/HashicorpVaultAccessAcceptanceTest.java
@@ -14,28 +14,35 @@ package tech.pegasys.signers.keystorage.hashicorp.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import tech.pegasys.plus.plugin.encryptedstorage.encryption.util.HashicorpConfigUtil;
-import tech.pegasys.signers.dsl.DockerClientFactory;
-import tech.pegasys.signers.dsl.hashicorp.HashicorpNode;
 import tech.pegasys.signing.hashicorp.HashicorpConnection;
 import tech.pegasys.signing.hashicorp.HashicorpConnectionFactory;
 import tech.pegasys.signing.hashicorp.config.HashicorpKeyConfig;
 import tech.pegasys.signing.hashicorp.config.loader.toml.TomlConfigLoader;
+import tech.pegasys.signing.hashicorp.dsl.DockerClientFactory;
+import tech.pegasys.signing.hashicorp.dsl.certificates.CertificateHelpers;
+import tech.pegasys.signing.hashicorp.dsl.hashicorp.HashicorpNode;
+import tech.pegasys.signing.hashicorp.util.HashicorpConfigUtil;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.cert.CertificateEncodingException;
+import java.util.Collections;
+import java.util.Optional;
 
 import com.github.dockerjava.api.DockerClient;
 import io.vertx.core.Vertx;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class HashicorpVaultAccessAcceptanceTest {
 
   private final Vertx vertx = Vertx.vertx();
+  final DockerClient docker = new DockerClientFactory().create();
   private HashicorpNode hashicorpNode;
-  final DockerClientFactory dockerClientFactory = new DockerClientFactory();
-  final DockerClient dockerClient = dockerClientFactory.create();
+
+  private final String SECRET_KEY = "storedSecetKey";
+  private final String SECRET_CONTENT = "secretValue";
 
   @AfterEach
   void cleanup() {
@@ -48,11 +55,20 @@ public class HashicorpVaultAccessAcceptanceTest {
       hashicorpNode.shutdown();
       hashicorpNode = null;
     }
+
+    try {
+      docker.close();
+    } catch (final Exception ignored) {
+    }
   }
 
   @Test
   void keyCanBeExtractedFromVault() throws IOException {
-    hashicorpNode = HashicorpNode.createAndStartHashicorp(dockerClient, false);
+    hashicorpNode = HashicorpNode.createAndStartHashicorp(docker, false);
+
+    final String hashicorpSecretHttpPath =
+        hashicorpNode.addSecretsToVault(
+            Collections.singletonMap(SECRET_KEY, SECRET_CONTENT), "acceptanceTestSecret");
 
     // create tomlfile
     final Path configFilePath =
@@ -60,8 +76,8 @@ public class HashicorpVaultAccessAcceptanceTest {
             hashicorpNode.getHost(),
             hashicorpNode.getPort(),
             hashicorpNode.getVaultToken(),
-            hashicorpNode.getSigningKeyPath(),
-            null,
+            hashicorpSecretHttpPath,
+            SECRET_KEY,
             30_000,
             false,
             null,
@@ -70,13 +86,23 @@ public class HashicorpVaultAccessAcceptanceTest {
 
     final String secretData = fetchSecretFromVault(configFilePath);
 
-    assertThat(secretData)
-        .isEqualTo("8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    assertThat(secretData).isEqualTo(SECRET_CONTENT);
   }
 
   @Test
-  void keyCanBeExtractedFromVaultOverTlsUsingWhitelist() throws IOException {
-    hashicorpNode = HashicorpNode.createAndStartHashicorp(dockerClient, true);
+  void keyCanBeExtractedFromVaultOverTlsUsingWhitelist(@TempDir final Path testDir)
+      throws IOException, CertificateEncodingException {
+    hashicorpNode = HashicorpNode.createAndStartHashicorp(docker, true);
+
+    final String hashicorpSecretHttpPath =
+        hashicorpNode.addSecretsToVault(
+            Collections.singletonMap(SECRET_KEY, SECRET_CONTENT), "acceptanceTestSecret");
+
+    final Path fingerprintFile = testDir.resolve("whitelist.tmp");
+    CertificateHelpers.populateFingerprintFile(
+        fingerprintFile,
+        hashicorpNode.getServerCertificate(),
+        Optional.of(hashicorpNode.getPort()));
 
     // create tomlfile
     final Path configFilePath =
@@ -84,18 +110,114 @@ public class HashicorpVaultAccessAcceptanceTest {
             hashicorpNode.getHost(),
             hashicorpNode.getPort(),
             hashicorpNode.getVaultToken(),
-            hashicorpNode.getSigningKeyPath(),
-            null,
+            hashicorpSecretHttpPath,
+            SECRET_KEY,
             30_000,
             true,
             "WHITELIST",
-            hashicorpNode.getKnownServerFilePath().get().toString(),
+            fingerprintFile.toString(),
             null);
 
     final String secretData = fetchSecretFromVault(configFilePath);
 
-    assertThat(secretData)
-        .isEqualTo("8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63");
+    assertThat(secretData).isEqualTo(SECRET_CONTENT);
+  }
+
+  @Test
+  void canConnectToHashicorpVaultUsingPkcs12Certificate(@TempDir final Path testDir)
+      throws IOException {
+    final String TRUST_STORE_PASSWORD = "password";
+    hashicorpNode = HashicorpNode.createAndStartHashicorp(docker, true);
+
+    final String hashicorpSecretHttpPath =
+        hashicorpNode.addSecretsToVault(
+            Collections.singletonMap(SECRET_KEY, SECRET_CONTENT), "acceptanceTestSecret");
+
+    final Path trustStorePath =
+        CertificateHelpers.createPkcs12TrustStore(
+            testDir, hashicorpNode.getServerCertificate(), TRUST_STORE_PASSWORD);
+
+    // create tomlfile
+    final Path configFilePath =
+        HashicorpConfigUtil.createConfigFile(
+            hashicorpNode.getHost(),
+            hashicorpNode.getPort(),
+            hashicorpNode.getVaultToken(),
+            hashicorpSecretHttpPath,
+            SECRET_KEY,
+            30_000,
+            true,
+            "PKCS12",
+            trustStorePath.toString(),
+            TRUST_STORE_PASSWORD);
+
+    final String secretData = fetchSecretFromVault(configFilePath);
+
+    assertThat(secretData).isEqualTo(SECRET_CONTENT);
+  }
+
+  @Test
+  void canConnectToHashicorpVaultUsingJksCertificate(@TempDir final Path testDir)
+      throws IOException {
+    final String TRUST_STORE_PASSWORD = "password";
+    hashicorpNode = HashicorpNode.createAndStartHashicorp(docker, true);
+
+    final String hashicorpSecretHttpPath =
+        hashicorpNode.addSecretsToVault(
+            Collections.singletonMap(SECRET_KEY, SECRET_CONTENT), "acceptanceTestSecret");
+
+    final Path trustStorePath =
+        CertificateHelpers.createJksTrustStore(
+            testDir, hashicorpNode.getServerCertificate(), TRUST_STORE_PASSWORD);
+
+    // create tomlfile
+    final Path configFilePath =
+        HashicorpConfigUtil.createConfigFile(
+            hashicorpNode.getHost(),
+            hashicorpNode.getPort(),
+            hashicorpNode.getVaultToken(),
+            hashicorpSecretHttpPath,
+            SECRET_KEY,
+            30_000,
+            true,
+            "JKS",
+            trustStorePath.toString(),
+            TRUST_STORE_PASSWORD);
+
+    final String secretData = fetchSecretFromVault(configFilePath);
+
+    assertThat(secretData).isEqualTo(SECRET_CONTENT);
+  }
+
+  @Test
+  void canConnectToHashicorpVaultUsingPemCertificate(@TempDir final Path testDir)
+      throws IOException, CertificateEncodingException {
+    hashicorpNode = HashicorpNode.createAndStartHashicorp(docker, true);
+
+    final String hashicorpSecretHttpPath =
+        hashicorpNode.addSecretsToVault(
+            Collections.singletonMap(SECRET_KEY, SECRET_CONTENT), "acceptanceTestSecret");
+
+    final Path trustStorePath = testDir.resolve("cert.crt");
+    hashicorpNode.getServerCertificate().writeCertificateToFile(trustStorePath);
+
+    // create tomlfile
+    final Path configFilePath =
+        HashicorpConfigUtil.createConfigFile(
+            hashicorpNode.getHost(),
+            hashicorpNode.getPort(),
+            hashicorpNode.getVaultToken(),
+            hashicorpSecretHttpPath,
+            SECRET_KEY,
+            30_000,
+            true,
+            "PEM",
+            trustStorePath.toString(),
+            null);
+
+    final String secretData = fetchSecretFromVault(configFilePath);
+
+    assertThat(secretData).isEqualTo(SECRET_CONTENT);
   }
 
   private String fetchSecretFromVault(final Path configFilePath) {

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/keystorage/hashicorp/tests/HashicorpVaultAccessAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/keystorage/hashicorp/tests/HashicorpVaultAccessAcceptanceTest.java
@@ -51,11 +51,13 @@ public class HashicorpVaultAccessAcceptanceTest {
     } catch (final Exception ignored) {
     }
 
-    if (hashicorpNode != null) {
-      hashicorpNode.shutdown();
-      hashicorpNode = null;
+    try {
+      if (hashicorpNode != null) {
+        hashicorpNode.shutdown();
+        hashicorpNode = null;
+      }
+    } catch (final Exception ignored) {
     }
-
     try {
       docker.close();
     } catch (final Exception ignored) {

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/DockerClientFactory.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/DockerClientFactory.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.signers.dsl;
+package tech.pegasys.signing.hashicorp.dsl;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/certificates/CertificateHelpers.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/certificates/CertificateHelpers.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signing.hashicorp.dsl.certificates;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.util.Optional;
+
+import org.apache.tuweni.net.tls.TLS;
+
+public class CertificateHelpers {
+
+  public static void populateFingerprintFile(
+      final Path knownHostsPath,
+      final SelfSignedCertificate selfSignedCert,
+      final Optional<Integer> port)
+      throws IOException, CertificateEncodingException {
+
+    final StringBuilder fingerPrintsToAdd = new StringBuilder();
+    final String portFragment = port.map(p -> String.format(":%d", p)).orElse("");
+    final String fingerprint = TLS.certificateHexFingerprint(selfSignedCert.getCertificate());
+    fingerPrintsToAdd.append(String.format("localhost%s %s%n", portFragment, fingerprint));
+    fingerPrintsToAdd.append(String.format("127.0.0.1%s %s%n", portFragment, fingerprint));
+    Files.writeString(knownHostsPath, fingerPrintsToAdd.toString());
+  }
+
+  public static Path createJksTrustStore(
+      final Path parentDir, final SelfSignedCertificate selfSignedCert, final String password) {
+    try {
+      final Path keyStorePath = parentDir.resolve("keystore.jks");
+      createTrustStore("JKS", selfSignedCert, password, keyStorePath);
+      return keyStorePath;
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to construct a JKS keystore.");
+    }
+  }
+
+  public static Path createPkcs12TrustStore(
+      final Path parentDir, final SelfSignedCertificate selfSignedCert, final String password) {
+    try {
+      final Path keyStorePath = parentDir.resolve("keystore.pfx");
+      createTrustStore("pkcs12", selfSignedCert, password, keyStorePath);
+      return keyStorePath;
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to construct a PKCS12 keystore.");
+    }
+  }
+
+  private static void createTrustStore(
+      final String keystoreType,
+      final SelfSignedCertificate selfSignedCert,
+      final String password,
+      final Path populatedFile)
+      throws CertificateException, NoSuchAlgorithmException, IOException, KeyStoreException {
+
+    final KeyStore ks = KeyStore.getInstance(keystoreType);
+    ks.load(null, null);
+
+    final Certificate certificate = selfSignedCert.getCertificate();
+    ks.setCertificateEntry("clientCert", certificate);
+    ks.setKeyEntry(
+        "client",
+        selfSignedCert.getKeyPair().getPrivate(),
+        password.toCharArray(),
+        new Certificate[] {certificate});
+
+    try (final FileOutputStream output = new FileOutputStream(populatedFile.toFile())) {
+      ks.store(output, password.toCharArray());
+    }
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/certificates/SelfSignedCertificate.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/certificates/SelfSignedCertificate.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.signers.dsl.hashicorp;
+package tech.pegasys.signing.hashicorp.dsl.certificates;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -22,9 +22,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.PrivateKey;
 import java.security.SecureRandom;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
@@ -51,36 +49,35 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
 
-/**
- * Utility class to generate temporary self-signed certificates with SAN extension for multiple DNS
- * and IP addresses in PEM formats for testing purposes using BouncyCastle APIs.
- *
- * <p>Note: DO NOT USE IN PRODUCTION. The generated stores and files are marked to be deleted on JVM
- * exit.
- */
-public final class SelfSignedCertificate {
+public class SelfSignedCertificate {
+
   private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
   private static final boolean IS_CA = true;
   private static final String distinguishedName = "CN=localhost";
   private static final List<String> sanHostNames = List.of("localhost");
   private static final List<String> sanIpAddresses = List.of("127.0.0.1");
-  private final Path certificatePath;
-  private final Path privateKeyPath;
 
-  private SelfSignedCertificate(final Path certificatePath, final Path privateKeyPath) {
-    this.certificatePath = certificatePath;
-    this.privateKeyPath = privateKeyPath;
+  private final KeyPair keyPair; // not sure if this is needed.
+  private final X509Certificate certificate;
+
+  public SelfSignedCertificate(final KeyPair keyPair, final X509Certificate certificate) {
+    this.keyPair = keyPair;
+    this.certificate = certificate;
   }
 
   public static SelfSignedCertificate generate() {
     try {
       final KeyPair keyPair = generateKeyPair();
-      return new SelfSignedCertificate(
-          createPemCertificateFile(generateSelfSignedCertificate(keyPair)),
-          createPemPrivateKeyFile(keyPair.getPrivate()));
+      return new SelfSignedCertificate(keyPair, generateSelfSignedCertificate(keyPair));
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private static KeyPair generateKeyPair() throws GeneralSecurityException {
+    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048, new SecureRandom());
+    return keyPairGenerator.generateKeyPair();
   }
 
   private static X509Certificate generateSelfSignedCertificate(final KeyPair keyPair)
@@ -111,12 +108,6 @@ public final class SelfSignedCertificate {
         .getCertificate(v3CertificateBuilder.build(contentSigner));
   }
 
-  private static KeyPair generateKeyPair() throws GeneralSecurityException {
-    final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-    keyPairGenerator.initialize(2048, new SecureRandom());
-    return keyPairGenerator.generateKeyPair();
-  }
-
   private static GeneralNames getSubjectAlternativeNames() {
     final List<GeneralName> hostGeneralNames =
         sanHostNames.stream()
@@ -134,35 +125,26 @@ public final class SelfSignedCertificate {
     return new GeneralNames(generalNames);
   }
 
-  private static Path createPemCertificateFile(final Certificate certificate)
-      throws IOException, CertificateEncodingException {
-    final Path certificatePath = Files.createTempFile("test", ".crt");
-    certificatePath.toFile().deleteOnExit();
+  public X509Certificate getCertificate() {
+    return certificate;
+  }
 
-    try (final BufferedWriter writer = Files.newBufferedWriter(certificatePath, UTF_8);
+  public KeyPair getKeyPair() {
+    return keyPair;
+  }
+
+  public void writePrivateKeyToFile(final Path outputFile) throws IOException {
+    try (final BufferedWriter writer = Files.newBufferedWriter(outputFile, UTF_8);
+        final PemWriter pemWriter = new PemWriter(writer)) {
+      pemWriter.writeObject(new PemObject("PRIVATE KEY", keyPair.getPrivate().getEncoded()));
+    }
+  }
+
+  public void writeCertificateToFile(final Path pemFile)
+      throws IOException, CertificateEncodingException {
+    try (final BufferedWriter writer = Files.newBufferedWriter(pemFile, UTF_8);
         final PemWriter pemWriter = new PemWriter(writer)) {
       pemWriter.writeObject(new PemObject("CERTIFICATE", certificate.getEncoded()));
     }
-
-    return certificatePath;
-  }
-
-  private static Path createPemPrivateKeyFile(final PrivateKey privateKey) throws IOException {
-    final Path privateKeyPath = Files.createTempFile("test", ".key");
-    privateKeyPath.toFile().deleteOnExit();
-
-    try (final BufferedWriter writer = Files.newBufferedWriter(privateKeyPath, UTF_8);
-        final PemWriter pemWriter = new PemWriter(writer)) {
-      pemWriter.writeObject(new PemObject("PRIVATE KEY", privateKey.getEncoded()));
-    }
-    return privateKeyPath;
-  }
-
-  public Path certificatePath() {
-    return certificatePath;
-  }
-
-  public Path privateKeyPath() {
-    return privateKeyPath;
   }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultCommands.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultCommands.java
@@ -64,29 +64,4 @@ public class HashicorpVaultCommands {
   public String[] vaultLoginCommand(final String rootToken) {
     return new String[] {"vault", "login", "-address=" + vaultUrl, rootToken};
   }
-
-  public List<String> constructVaultEnvVars() {
-    /*
-    try {
-      final URL url = new URL(vaultUrl);
-      final String addressConfig = String.format("\"address\":0.0.0.0:%d", url.getPort());
-      final List<String> environmentVariables =
-          List.of(
-              "VAULT_LOCAL_CONFIG={\"storage\": {\"inmem\":{}}, "
-                  + "\"default_lease_ttl\": \"168h\", \"max_lease_ttl\": \"720h\", "
-                  + "\"listener\": {\"tcp\": {"
-                  + addressConfig + ","
-                  + tlsEnvConfig()
-                  + "}}}",
-              "VAULT_SKIP_VERIFY=true");
-
-      return emptyList();
-    } catch(final MalformedURLException e) {
-      throw new RuntimeException("Illegal Vault URL, unable to create required env vars.", e);
-    }
-
-     */
-
-    return emptyList();
-  }
 }

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultCommands.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultCommands.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signing.hashicorp.dsl.hashicorp;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Map;
+
+// This assumes there is a Vault Server running at teh vault URL (for AT, typically in a docker)
+public class HashicorpVaultCommands {
+
+  private final String vaultUrl;
+
+  public HashicorpVaultCommands(final String vaultUrl) {
+    this.vaultUrl = vaultUrl;
+  }
+
+  public String[] vaultStatusCommand() {
+    return new String[] {"vault", "status", "-address=" + vaultUrl};
+  }
+
+  public String[] vaultInitCommand() {
+    return new String[] {
+      "vault",
+      "operator",
+      "init",
+      "-key-shares=1",
+      "-key-threshold=1",
+      "-format=json",
+      "-address=" + vaultUrl
+    };
+  }
+
+  public String[] vaultEnableSecretEngineCommand(final String vaultRootPath) {
+    return new String[] {
+      "vault", "secrets", "enable", "-address=" + vaultUrl, "-path=" + vaultRootPath, "kv-v2",
+    };
+  }
+
+  public String[] unsealVault(final String unsealKey) {
+    return new String[] {
+      "vault", "operator", "unseal", "-address=" + vaultUrl, "-format=json", unsealKey
+    };
+  }
+
+  public String[] vaultPutSecretCommand(final Map.Entry<String, String> entry, final String path) {
+    final String paramString = String.format("%s=%s", entry.getKey(), entry.getValue());
+    return new String[] {
+      "vault", "kv", "put", "-address=" + vaultUrl, path, paramString,
+    };
+  }
+
+  public String[] vaultLoginCommand(final String rootToken) {
+    return new String[] {"vault", "login", "-address=" + vaultUrl, rootToken};
+  }
+
+  public List<String> constructVaultEnvVars() {
+    /*
+    try {
+      final URL url = new URL(vaultUrl);
+      final String addressConfig = String.format("\"address\":0.0.0.0:%d", url.getPort());
+      final List<String> environmentVariables =
+          List.of(
+              "VAULT_LOCAL_CONFIG={\"storage\": {\"inmem\":{}}, "
+                  + "\"default_lease_ttl\": \"168h\", \"max_lease_ttl\": \"720h\", "
+                  + "\"listener\": {\"tcp\": {"
+                  + addressConfig + ","
+                  + tlsEnvConfig()
+                  + "}}}",
+              "VAULT_SKIP_VERIFY=true");
+
+      return emptyList();
+    } catch(final MalformedURLException e) {
+      throw new RuntimeException("Illegal Vault URL, unable to create required env vars.", e);
+    }
+
+     */
+
+    return emptyList();
+  }
+}

--- a/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultTokens.java
+++ b/acceptance-tests/src/testFixtures/java/tech/pegasys/signing/hashicorp/dsl/hashicorp/HashicorpVaultTokens.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.signers.dsl.hashicorp;
+package tech.pegasys.signing.hashicorp.dsl.hashicorp;
 
 public class HashicorpVaultTokens {
   private final String unsealKey;

--- a/build.gradle
+++ b/build.gradle
@@ -427,7 +427,6 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
   }
 }
 
-//configurations { annotationProcessor }
 
 // Prevent errorprone-checks being dependent upon errorprone-checks!
 // However, ensure all subprojects comply with the custom rules.

--- a/keystorage/build.gradle
+++ b/keystorage/build.gradle
@@ -1,0 +1,1 @@
+jar { enabled = false }

--- a/keystorage/hashicorp/build.gradle
+++ b/keystorage/hashicorp/build.gradle
@@ -49,13 +49,6 @@ dependencies {
   integrationTestImplementation 'org.mock-server:mockserver-netty'
   integrationTestImplementation sourceSets.testFixtures.output
 
-  testFixturesImplementation 'com.github.docker-java:docker-java'
-  testFixturesImplementation 'org.apache.logging.log4j:log4j-core'
-  testFixturesImplementation 'org.apache.logging.log4j:log4j-slf4j-impl'
-  testFixturesImplementation 'org.apache.logging.log4j:log4j-api'
-  testFixturesImplementation 'org.assertj:assertj-core'
-  testFixturesImplementation 'org.awaitility:awaitility'
-  testFixturesImplementation 'org.apache.tuweni:tuweni-net'
-  testFixturesImplementation 'org.junit.jupiter:junit-jupiter-engine'
-  testFixturesImplementation 'org.bouncycastle:bcpkix-jdk15on'
+
+  errorprone("com.google.errorprone:error_prone_core")
 }

--- a/keystorage/hashicorp/src/integrationTest/java/tech/pegasys/signing/hashicorp/HashicorpIntegrationTest.java
+++ b/keystorage/hashicorp/src/integrationTest/java/tech/pegasys/signing/hashicorp/HashicorpIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.mockserver.configuration.ConfigurationProperties.javaKeyStoreF
 import static org.mockserver.configuration.ConfigurationProperties.javaKeyStorePassword;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
-import static tech.pegasys.plus.plugin.encryptedstorage.encryption.util.HashicorpConfigUtil.createConfigFile;
+import static tech.pegasys.signing.hashicorp.util.HashicorpConfigUtil.createConfigFile;
 
 import tech.pegasys.signing.hashicorp.config.HashicorpKeyConfig;
 import tech.pegasys.signing.hashicorp.config.loader.toml.TomlConfigLoader;

--- a/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/HashicorpConnection.java
+++ b/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/HashicorpConnection.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLException;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpClient;
@@ -68,8 +69,10 @@ public class HashicorpConnection {
       } else if (underlyingFailure instanceof TimeoutException) {
         throw new HashicorpException(
             "Hashicorp Vault failed to respond within expected timeout.", underlyingFailure);
+      } else if (underlyingFailure instanceof SSLException) {
+        throw new HashicorpException("Failed during SSL negotiation.", underlyingFailure);
       }
-      throw new HashicorpException(ERROR_HTTP_CLIENT_CALL, e.getCause());
+      throw new HashicorpException(ERROR_HTTP_CLIENT_CALL, underlyingFailure);
     } catch (final InterruptedException e) {
       throw new HashicorpException("Waiting for Hashicorp response was terminated unexpectedly");
     }

--- a/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/config/loader/toml/TomlConfigLoader.java
+++ b/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/config/loader/toml/TomlConfigLoader.java
@@ -156,7 +156,9 @@ public class TomlConfigLoader {
 
     return Optional.of(
         new TlsOptions(
-            Optional.ofNullable(trustStoreType), Path.of(trustStorePath), trustStorePassword));
+            Optional.ofNullable(trustStoreType),
+            trustStorePath == null ? null : Path.of(trustStorePath),
+            trustStorePassword));
   }
 
   private TrustStoreType decodeTrustStoreType(final String trustStoreString) {

--- a/keystorage/hashicorp/src/test/java/tech/pegasys/signing/hashicorp/loader/TomlConfigLoaderTest.java
+++ b/keystorage/hashicorp/src/test/java/tech/pegasys/signing/hashicorp/loader/TomlConfigLoaderTest.java
@@ -15,12 +15,12 @@ package tech.pegasys.signing.hashicorp.loader;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import tech.pegasys.plus.plugin.encryptedstorage.encryption.util.HashicorpConfigUtil;
 import tech.pegasys.signing.hashicorp.HashicorpException;
 import tech.pegasys.signing.hashicorp.TrustStoreType;
 import tech.pegasys.signing.hashicorp.config.HashicorpKeyConfig;
 import tech.pegasys.signing.hashicorp.config.TlsOptions;
 import tech.pegasys.signing.hashicorp.config.loader.toml.TomlConfigLoader;
+import tech.pegasys.signing.hashicorp.util.HashicorpConfigUtil;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/keystorage/hashicorp/src/testFixtures/java/tech/pegasys/signing/hashicorp/util/HashicorpConfigUtil.java
+++ b/keystorage/hashicorp/src/testFixtures/java/tech/pegasys/signing/hashicorp/util/HashicorpConfigUtil.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.plus.plugin.encryptedstorage.encryption.util;
+package tech.pegasys.signing.hashicorp.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempFile;


### PR DESCRIPTION
Allows any key to be stored in the hashicorp vault.
Allows users of the HashicorpNode to get access to the underlying SelfSignedCertificate, such that it can be formatted appropriately, then used to construct a HashicorpConnection.