### PR TITLE
Rework minor issues

### DIFF
--- a/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/HashicorpConnection.java
+++ b/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/HashicorpConnection.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLException;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpClient;
@@ -68,8 +69,10 @@ public class HashicorpConnection {
       } else if (underlyingFailure instanceof TimeoutException) {
         throw new HashicorpException(
             "Hashicorp Vault failed to respond within expected timeout.", underlyingFailure);
+      } else if (underlyingFailure instanceof SSLException) {
+        throw new HashicorpException("Failed during SSL negotiation.", underlyingFailure);
       }
-      throw new HashicorpException(ERROR_HTTP_CLIENT_CALL, e.getCause());
+      throw new HashicorpException(ERROR_HTTP_CLIENT_CALL, underlyingFailure);
     } catch (final InterruptedException e) {
       throw new HashicorpException("Waiting for Hashicorp response was terminated unexpectedly");
     }

--- a/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/config/loader/toml/TomlConfigLoader.java
+++ b/keystorage/hashicorp/src/main/java/tech/pegasys/signing/hashicorp/config/loader/toml/TomlConfigLoader.java
@@ -156,7 +156,9 @@ public class TomlConfigLoader {
 
     return Optional.of(
         new TlsOptions(
-            Optional.ofNullable(trustStoreType), Path.of(trustStorePath), trustStorePassword));
+            Optional.ofNullable(trustStoreType),
+            trustStorePath == null ? null : Path.of(trustStorePath),
+            trustStorePassword));
   }
 
   private TrustStoreType decodeTrustStoreType(final String trustStoreString) {


### PR DESCRIPTION
Two minor repairs:
* HashicorpConnection now explicitly shows SSL handshaking failures
* TomlLoading treats the trustStorePath as optional (rather than throwing if its missing)