### PR TITLE
Remove teku BLS dependency

### DIFF
--- a/bls-keystore/build.gradle
+++ b/bls-keystore/build.gradle
@@ -21,7 +21,6 @@ jar {
 }
 
 dependencies {
-  implementation 'tech.pegasys.teku.internal:bls'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.bouncycastle:bcprov-jdk15on'
   implementation 'com.google.guava:guava'

--- a/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
+++ b/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
@@ -124,7 +124,7 @@ class KeyStoreTest {
   void encryptWithKdfAndCipherFunction(
       final KdfParam kdfParam, final Bytes expectedChecksum, final Bytes encryptedCipherMessage) {
     final KeyStoreData keyStoreData =
-        KeyStore.encrypt(BLS_PRIVATE_KEY, PASSWORD, "", kdfParam, CIPHER);
+        KeyStore.encrypt(BLS_PRIVATE_KEY, BLS_PUB_KEY, PASSWORD, "", kdfParam, CIPHER);
     assertThat(keyStoreData.getCrypto().getChecksum().getMessage()).isEqualTo(expectedChecksum);
     assertThat(keyStoreData.getCrypto().getCipher().getMessage()).isEqualTo(encryptedCipherMessage);
     assertThat(keyStoreData.getVersion()).isEqualTo(KeyStoreData.KEYSTORE_VERSION);
@@ -207,7 +207,7 @@ class KeyStoreTest {
   private void encryptSaveAndReloadKeyStore(final Path tempDir, final KdfParam kdfParam)
       throws IOException {
     final KeyStoreData keyStoreData =
-        KeyStore.encrypt(BLS_PRIVATE_KEY, PASSWORD, "", kdfParam, CIPHER);
+        KeyStore.encrypt(BLS_PRIVATE_KEY, BLS_PUB_KEY, PASSWORD, "", kdfParam, CIPHER);
     final Path tempKeyStoreFile = Files.createTempFile(tempDir, "keystore", ".json");
     assertThatCode(() -> KeyStoreLoader.saveToFile(tempKeyStoreFile, keyStoreData))
         .doesNotThrowAnyException();

--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,15 @@ allprojects {
 
       check('InsecureCryptoUsage', CheckSeverity.WARN)
       check('WildcardImport', CheckSeverity.WARN)
+
+      // This check is broken in Java 12.  See https://github.com/google/error-prone/issues/1257
+      if (JavaVersion.current() == JavaVersion.VERSION_12) {
+        check('Finally', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+      }
+      // This check is broken after Java 12.  See https://github.com/google/error-prone/issues/1352
+      if (JavaVersion.current() > JavaVersion.VERSION_12) {
+        check('TypeParameterUnusedInFormals', net.ltgt.gradle.errorprone.CheckSeverity.OFF)
+      }
     }
 
     options.encoding = 'UTF-8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.jvmargs=-Xmx1g
-version=0.0.1-SNAPSHOT
+version=0.0.2-SNAPSHOT

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -58,7 +58,5 @@ dependencyManagement {
     dependency 'org.mockito:mockito-core:3.2.4'
     dependency 'org.mockito:mockito-inline:3.2.4'
     dependency 'org.mockito:mockito-junit-jupiter:3.2.4'
-
-    dependency 'tech.pegasys.teku.internal:bls:0.8.2-SNAPSHOT'
   }
 }


### PR DESCRIPTION
 --Pass public key to encrypt method rather than calculating it from private key
 --Change version to 0.0.2-SNAPSHOT as this is breaking change with 0.0.1-SNAPSHOT
 -- Fix errorprone checks to allow build with JDK12+

Signed-off-by: Usman Saleem <usman@usmans.info>