### PR TITLE
Create A FileSignerConfig

### DIFF
--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileBasedSignerFactory.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileBasedSignerFactory.java
@@ -36,6 +36,10 @@ public class FileBasedSignerFactory {
   private static final String DECRYPTING_KEY_FILE_MESSAGE =
       "Error when decrypting key for the file based signer. ";
 
+  public static Signer createSigner(final FileSignerConfig signerConfig) {
+    return createSigner(signerConfig.getKeystoreFile(), signerConfig.getKeystorePasswordFile());
+  }
+
   public static Signer createSigner(final Path keyFilePath, final Path passwordFilePath) {
     final String password;
     try {
@@ -48,6 +52,7 @@ public class FileBasedSignerFactory {
       LOG.error(message, e);
       throw new SignerInitializationException(message, e);
     }
+
     try {
       final Credentials credentials = WalletUtils.loadCredentials(password, keyFilePath.toFile());
       return new CredentialSigner(credentials);

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileBasedSignerFactory.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileBasedSignerFactory.java
@@ -52,7 +52,6 @@ public class FileBasedSignerFactory {
       LOG.error(message, e);
       throw new SignerInitializationException(message, e);
     }
-
     try {
       final Credentials credentials = WalletUtils.loadCredentials(password, keyFilePath.toFile());
       return new CredentialSigner(credentials);

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileSignerConfig.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/FileSignerConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signers.secp256k1.filebased;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class FileSignerConfig {
+
+  private final Path keystoreFile;
+  private final Path keystorePasswordFile;
+
+  public FileSignerConfig(final Path keystoreFile, Path keystorePasswordFile) {
+    this.keystoreFile = keystoreFile;
+    this.keystorePasswordFile = keystorePasswordFile;
+  }
+
+  public Path getKeystoreFile() {
+    return keystoreFile;
+  }
+
+  public Path getKeystorePasswordFile() {
+    return keystorePasswordFile;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FileSignerConfig that = (FileSignerConfig) o;
+    return Objects.equals(keystoreFile, that.keystoreFile)
+        && Objects.equals(keystorePasswordFile, that.keystorePasswordFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keystoreFile, keystorePasswordFile);
+  }
+}

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/MultiKeySignerProvider.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/MultiKeySignerProvider.java
@@ -141,11 +141,10 @@ public class MultiKeySignerProvider implements SignerProvider, MultiSignerFactor
   @Override
   public Signer createSigner(final FileBasedSigningMetadataFile metadataFile) {
     try {
-      return FileBasedSignerFactory.createSigner(
-          metadataFile.getKeyPath(), metadataFile.getPasswordPath());
+      return FileBasedSignerFactory.createSigner(metadataFile.getConfig());
 
     } catch (final SignerInitializationException e) {
-      LOG.error("Unable to load signer with key " + metadataFile.getKeyPath().getFileName(), e);
+      LOG.error("Unable to construct Filebased signer from " + metadataFile.getFilename());
       return null;
     }
   }

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoader.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoader.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import tech.pegasys.signers.hashicorp.config.HashicorpKeyConfig;
 import tech.pegasys.signers.hashicorp.config.loader.toml.TomlConfigLoader;
 import tech.pegasys.signers.secp256k1.azure.AzureConfig.AzureConfigBuilder;
+import tech.pegasys.signers.secp256k1.filebased.FileSignerConfig;
 import tech.pegasys.signers.secp256k1.multikey.metadata.AzureSigningMetadataFile;
 import tech.pegasys.signers.secp256k1.multikey.metadata.FileBasedSigningMetadataFile;
 import tech.pegasys.signers.secp256k1.multikey.metadata.HashicorpSigningMetadataFile;
@@ -126,7 +127,8 @@ public class SigningMetadataTomlConfigLoader {
     final Path keyPath = makeRelativePathAbsolute(keyFilename);
     final String passwordFilename = table.getString("password-file");
     final Path passwordPath = makeRelativePathAbsolute(passwordFilename);
-    return Optional.of(new FileBasedSigningMetadataFile(filename, keyPath, passwordPath));
+    return Optional.of(
+        new FileBasedSigningMetadataFile(filename, new FileSignerConfig(keyPath, passwordPath)));
   }
 
   private Optional<SigningMetadataFile> getAzureBasedSigningMetadataFromToml(

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/metadata/FileBasedSigningMetadataFile.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/multikey/metadata/FileBasedSigningMetadataFile.java
@@ -13,30 +13,22 @@
 package tech.pegasys.signers.secp256k1.multikey.metadata;
 
 import tech.pegasys.signers.secp256k1.api.Signer;
+import tech.pegasys.signers.secp256k1.filebased.FileSignerConfig;
 import tech.pegasys.signers.secp256k1.multikey.MultiSignerFactory;
-
-import java.nio.file.Path;
 
 import com.google.common.base.Objects;
 
 public class FileBasedSigningMetadataFile extends SigningMetadataFile {
 
-  private final Path keyPath;
-  private final Path passwordPath;
+  private final FileSignerConfig config;
 
-  public FileBasedSigningMetadataFile(
-      final String filename, final Path keyPath, final Path passwordPath) {
+  public FileBasedSigningMetadataFile(final String filename, final FileSignerConfig config) {
     super(filename);
-    this.keyPath = keyPath;
-    this.passwordPath = passwordPath;
+    this.config = config;
   }
 
-  public Path getKeyPath() {
-    return keyPath;
-  }
-
-  public Path getPasswordPath() {
-    return passwordPath;
+  public FileSignerConfig getConfig() {
+    return config;
   }
 
   @Override
@@ -48,14 +40,12 @@ public class FileBasedSigningMetadataFile extends SigningMetadataFile {
       return false;
     }
     final FileBasedSigningMetadataFile that = (FileBasedSigningMetadataFile) o;
-    return Objects.equal(filename, that.filename)
-        && Objects.equal(keyPath, that.keyPath)
-        && Objects.equal(passwordPath, that.passwordPath);
+    return Objects.equal(filename, that.filename) && Objects.equal(config, that.config);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(filename, keyPath, passwordPath);
+    return Objects.hashCode(filename, config);
   }
 
   @Override

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/FileBasedSigningMetadataFileTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/FileBasedSigningMetadataFileTest.java
@@ -33,8 +33,10 @@ class FileBasedSigningMetadataFileTest {
 
     assertThat(fileBasedSigningMetadataFile.getFilename())
         .matches(LOWERCASE_ADDRESS + CONFIG_FILE_EXTENSION);
-    assertThat(fileBasedSigningMetadataFile.getKeyPath().toFile().toString()).matches(KEY_FILE);
-    assertThat(fileBasedSigningMetadataFile.getPasswordPath().toFile().toString())
+    assertThat(fileBasedSigningMetadataFile.getConfig().getKeystoreFile().toFile().toString())
+        .matches(KEY_FILE);
+    assertThat(
+            fileBasedSigningMetadataFile.getConfig().getKeystorePasswordFile().toFile().toString())
         .matches(PASSWORD_FILE);
   }
 
@@ -46,8 +48,10 @@ class FileBasedSigningMetadataFileTest {
 
     assertThat(fileBasedSigningMetadataFile.getFilename())
         .matches(prefix + PREFIX_ADDRESS + CONFIG_FILE_EXTENSION);
-    assertThat(fileBasedSigningMetadataFile.getKeyPath().toFile().toString()).matches(KEY_FILE);
-    assertThat(fileBasedSigningMetadataFile.getPasswordPath().toFile().toString())
+    assertThat(fileBasedSigningMetadataFile.getConfig().getKeystoreFile().toFile().toString())
+        .matches(KEY_FILE);
+    assertThat(
+            fileBasedSigningMetadataFile.getConfig().getKeystorePasswordFile().toFile().toString())
         .matches(PASSWORD_FILE);
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/MetadataFileFixture.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/MetadataFileFixture.java
@@ -14,6 +14,7 @@ package tech.pegasys.signers.secp256k1.multikey;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import tech.pegasys.signers.secp256k1.filebased.FileSignerConfig;
 import tech.pegasys.signers.secp256k1.multikey.metadata.FileBasedSigningMetadataFile;
 
 import java.io.File;
@@ -75,8 +76,8 @@ public class MetadataFileFixture {
 
       return new FileBasedSigningMetadataFile(
           metadataPath.getFileName().toString(),
-          new File(keyFilename).toPath(),
-          new File(passwordFilename).toPath());
+          new FileSignerConfig(
+              new File(keyFilename).toPath(), new File(passwordFilename).toPath()));
 
     } catch (URISyntaxException e) {
       fail("URI Syntax Exception" + metadataFilename);

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/MultiKeySignerProviderTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/MultiKeySignerProviderTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.signers.secp256k1.api.PublicKey;
 import tech.pegasys.signers.secp256k1.api.Signer;
 import tech.pegasys.signers.secp256k1.azure.AzureKeyVaultAuthenticator;
 import tech.pegasys.signers.secp256k1.azure.AzureKeyVaultSignerFactory;
+import tech.pegasys.signers.secp256k1.filebased.FileSignerConfig;
 import tech.pegasys.signers.secp256k1.multikey.metadata.FileBasedSigningMetadataFile;
 import tech.pegasys.signers.secp256k1.multikey.metadata.SigningMetadataFile;
 
@@ -123,10 +124,12 @@ class MultiKeySignerProviderTest {
   void signerIsLoadedSuccessfullyWhenAddressHasCaseMismatchToFilename() throws URISyntaxException {
     final FileBasedSigningMetadataFile capitalisedMetadata =
         new FileBasedSigningMetadataFile(
-            LOWERCASE_ADDRESS.toUpperCase() + ".toml",
-            Path.of(Resources.getResource("metadata-toml-configs").toURI()).resolve(KEY_FILENAME),
-            Path.of(Resources.getResource("metadata-toml-configs").toURI())
-                .resolve(PASSWORD_FILENAME));
+            LOWERCASE_ADDRESS + ".toml",
+            new FileSignerConfig(
+                Path.of(Resources.getResource("metadata-toml-configs").toURI())
+                    .resolve(KEY_FILENAME),
+                Path.of(Resources.getResource("metadata-toml-configs").toURI())
+                    .resolve(PASSWORD_FILENAME)));
 
     final Signer signer = signerFactory.createSigner(capitalisedMetadata);
     assertThat(signer).isNotNull();
@@ -139,9 +142,11 @@ class MultiKeySignerProviderTest {
     final FileBasedSigningMetadataFile capitalisedMetadata =
         new FileBasedSigningMetadataFile(
             LOWERCASE_ADDRESS + ".toml",
-            Path.of(Resources.getResource("metadata-toml-configs").toURI()).resolve(KEY_FILENAME),
-            Path.of(Resources.getResource("metadata-toml-configs").toURI())
-                .resolve(PASSWORD_FILENAME));
+            new FileSignerConfig(
+                Path.of(Resources.getResource("metadata-toml-configs").toURI())
+                    .resolve(KEY_FILENAME),
+                Path.of(Resources.getResource("metadata-toml-configs").toURI())
+                    .resolve(PASSWORD_FILENAME)));
 
     when(loader.loadMetadata(any())).thenReturn(Optional.of(capitalisedMetadata));
 

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoaderTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoaderTest.java
@@ -70,12 +70,13 @@ class SigningMetadataTomlConfigLoaderTest {
     final Optional<SigningMetadataFile> loadedMetadataFile = loader.loadMetadata(filter);
 
     assertThat(loadedMetadataFile).isNotEmpty();
-    final FileBasedSigningMetadataFile fileBasedSigningMetadata =
+    final FileBasedSigningMetadataFile loadedMetaData =
         (FileBasedSigningMetadataFile) loadedMetadataFile.get();
-    assertThat(fileBasedSigningMetadata.getKeyPath())
-        .isEqualTo(fileBasedSigningMetadataFile.getKeyPath());
-    assertThat(fileBasedSigningMetadata.getPasswordPath())
-        .isEqualTo(fileBasedSigningMetadataFile.getPasswordPath());
+    assertThat(loadedMetaData.getConfig().getKeystoreFile())
+        .isEqualTo(fileBasedSigningMetadataFile.getConfig().getKeystoreFile());
+
+    assertThat(loadedMetaData.getConfig().getKeystorePasswordFile())
+        .isEqualTo(fileBasedSigningMetadataFile.getConfig().getKeystorePasswordFile());
   }
 
   @Test
@@ -232,8 +233,9 @@ class SigningMetadataTomlConfigLoaderTest {
     final FileBasedSigningMetadataFile metadataFile =
         (FileBasedSigningMetadataFile) metadataFiles.toArray()[0];
 
-    assertThat(metadataFile.getKeyPath()).isEqualTo(configsDirectory.resolve("./path/to/k.key"));
-    assertThat(metadataFile.getPasswordPath())
+    assertThat(metadataFile.getConfig().getKeystoreFile())
+        .isEqualTo(configsDirectory.resolve("./path/to/k.key"));
+    assertThat(metadataFile.getConfig().getKeystorePasswordFile())
         .isEqualTo(configsDirectory.resolve("./path/to/p.password"));
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoaderTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/multikey/SigningMetadataTomlConfigLoaderTest.java
@@ -70,12 +70,12 @@ class SigningMetadataTomlConfigLoaderTest {
     final Optional<SigningMetadataFile> loadedMetadataFile = loader.loadMetadata(filter);
 
     assertThat(loadedMetadataFile).isNotEmpty();
-    final FileBasedSigningMetadataFile loadedMetaData =
+    final FileBasedSigningMetadataFile fileBasedSigningMetadata =
         (FileBasedSigningMetadataFile) loadedMetadataFile.get();
-    assertThat(loadedMetaData.getConfig().getKeystoreFile())
+    assertThat(fileBasedSigningMetadata.getConfig().getKeystoreFile())
         .isEqualTo(fileBasedSigningMetadataFile.getConfig().getKeystoreFile());
 
-    assertThat(loadedMetaData.getConfig().getKeystorePasswordFile())
+    assertThat(fileBasedSigningMetadata.getConfig().getKeystorePasswordFile())
         .isEqualTo(fileBasedSigningMetadataFile.getConfig().getKeystorePasswordFile());
   }
 


### PR DESCRIPTION
The FileSigner is loaded via slightly different mechanism than Hashicorp and Azure, in that it didn't wrap its config params in a specific struct.

This is a useful mechanism moving forwards, and so has been introduced.

This does not affect outward facing CLI or TOML file strucures.