### PR TITLE
Resolve Azure failing to sign twice

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/AzureBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/AzureBasedTomlLoadingAcceptanceTest.java
@@ -35,7 +35,7 @@ public class AzureBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestB
   @BeforeAll
   static void preChecks() {
     Assumptions.assumeTrue(
-        clientId != null && clientSecret != null && keyVaultName != null && tenantId != null
+        clientId != null && clientSecret != null && keyVaultName != null && tenantId != null,
         "Ensure Azure env variables are set");
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/AzureBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/AzureBasedTomlLoadingAcceptanceTest.java
@@ -35,8 +35,8 @@ public class AzureBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestB
   @BeforeAll
   static void preChecks() {
     Assumptions.assumeTrue(
-        clientId != null && clientSecret != null,
-        "Ensure Azure client id and client secret env variables are set");
+        clientId != null && clientSecret != null && keyVaultName != null && tenantId != null
+        "Ensure Azure env variables are set");
   }
 
   @Test

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyAzureTransactionSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyAzureTransactionSignerAcceptanceTest.java
@@ -30,10 +30,10 @@ public class MultiKeyAzureTransactionSignerAcceptanceTest
   static final String tenantId = System.getenv("AZURE_TENANT_ID");
 
   @BeforeAll
-  public static void checkAzureCredentials() {
+  static void preChecks() {
     Assumptions.assumeTrue(
-        clientId != null && clientSecret != null,
-        "Ensure Azure client id and client secret env variables are set");
+        clientId != null && clientSecret != null && keyVaultName != null && tenantId != null,
+        "Ensure Azure env variables are set");
   }
 
   @Test

--- a/signing/secp256k1/impl/build.gradle
+++ b/signing/secp256k1/impl/build.gradle
@@ -57,6 +57,9 @@ dependencies {
   testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation(testFixtures(project(":keystorage:hashicorp")))
 
+  testImplementation 'com.azure:azure-security-keyvault-keys'
+  testImplementation 'com.azure:azure-identity'
+
   testFixturesImplementation project(':signing:secp256k1:api')
   testFixturesImplementation 'org.apache.tuweni:tuweni-bytes'
 

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
@@ -12,10 +12,12 @@
  */
 package tech.pegasys.signers.secp256k1.azure;
 
+import tech.pegasys.signers.azure.AzureKeyVault;
 import tech.pegasys.signers.secp256k1.PublicKeyImpl;
 import tech.pegasys.signers.secp256k1.api.PublicKey;
 import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
+import tech.pegasys.signers.secp256k1.common.SignerInitializationException;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -32,19 +34,36 @@ import org.web3j.crypto.Sign;
 
 public class AzureKeyVaultSigner implements Signer {
 
+  public static final String INACCESSIBLE_KEY_ERROR = "Failed to authenticate to vault.";
+
   private static final Logger LOG = LogManager.getLogger();
 
-  final CryptographyClient cryptoClient;
+  private final AzureConfig config;
   private final PublicKeyImpl publicKey;
   private final SignatureAlgorithm signingAlgo = SignatureAlgorithm.fromString("ECDSA256");
 
-  public AzureKeyVaultSigner(final CryptographyClient cryptoClient, final Bytes publicKey) {
-    this.cryptoClient = cryptoClient;
+  public AzureKeyVaultSigner(final AzureConfig config, final Bytes publicKey) {
+    this.config = config;
     this.publicKey = new PublicKeyImpl(publicKey);
   }
 
   @Override
   public Signature sign(byte[] data) {
+    final AzureKeyVault vault;
+    try {
+      vault =
+          new AzureKeyVault(
+              config.getClientId(),
+              config.getClientSecret(),
+              config.getTenantId(),
+              config.getKeyVaultName());
+    } catch (final Exception e) {
+      LOG.error("Failed to connect to vault", e);
+      throw new SignerInitializationException(INACCESSIBLE_KEY_ERROR, e);
+    }
+
+    final CryptographyClient cryptoClient =
+        vault.fetchKey(config.getKeyName(), config.getKeyVersion());
     final byte[] hash = Hash.sha3(data);
     final SignResult result = cryptoClient.sign(signingAlgo, hash);
     final byte[] signature = result.getSignature();

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerFactory.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerFactory.java
@@ -61,6 +61,6 @@ public class AzureKeyVaultSignerFactory {
     final JsonWebKey jsonWebKey = cryptoClient.getKey().getKey();
     final Bytes rawPublicKey =
         Bytes.concatenate(Bytes.wrap(jsonWebKey.getX()), Bytes.wrap(jsonWebKey.getY()));
-    return new AzureKeyVaultSigner(cryptoClient, rawPublicKey);
+    return new AzureKeyVaultSigner(config, rawPublicKey);
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSignerTest.java
@@ -16,14 +16,23 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import tech.pegasys.signers.secp256k1.api.Signer;
 
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class AzureSignerTest {
+public class AzureKeyVaultSignerTest {
 
   private static final String clientId = System.getenv("AZURE_CLIENT_ID");
   private static final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
   private static final String keyVaultName = System.getenv("AZURE_KEY_VAULT_NAME");
   private static final String tenantId = System.getenv("AZURE_TENANT_ID");
+
+  @BeforeAll
+  static void preChecks() {
+    Assumptions.assumeTrue(
+        clientId != null && clientSecret != null && keyVaultName != null && tenantId != null,
+        "Ensure Azure env variables are set");
+  }
 
   @Test
   public void azureSignerCanSignTwice() {

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/azure/AzureSignerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signers.secp256k1.azure;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import tech.pegasys.signers.secp256k1.api.Signer;
+
+import org.junit.jupiter.api.Test;
+
+public class AzureSignerTest {
+
+  private static final String clientId = System.getenv("AZURE_CLIENT_ID");
+  private static final String clientSecret = System.getenv("AZURE_CLIENT_SECRET");
+  private static final String keyVaultName = System.getenv("AZURE_KEY_VAULT_NAME");
+  private static final String tenantId = System.getenv("AZURE_TENANT_ID");
+
+  @Test
+  public void azureSignerCanSignTwice() {
+    final AzureConfig config =
+        new AzureConfig(keyVaultName, "TestKey", "", clientId, clientSecret, tenantId);
+
+    final AzureKeyVaultSignerFactory factory = new AzureKeyVaultSignerFactory();
+    final Signer signer = factory.createSigner(config);
+    signer.sign("Hello World".getBytes(UTF_8));
+    signer.sign("Hello World".getBytes(UTF_8));
+  }
+}


### PR DESCRIPTION
The new Azure libraries appear to have a problem whereby the CryptographicClient can only perform a single signing operation - all subsequent attempts fail.

As such, the AzureSignerProvider is required to re-create the CryptographicClient on EVERY signing request.

When Azure resolves their issues, this work can be reverted.