### PR TITLE
Allow CredentialSigner to take data-hashes

### DIFF
--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/CredentialSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/filebased/CredentialSigner.java
@@ -27,15 +27,21 @@ public class CredentialSigner implements Signer {
 
   private final Credentials credentials;
   private final ECPublicKey publicKey;
+  private final boolean needToHash;
 
-  public CredentialSigner(final Credentials credentials) {
+  public CredentialSigner(final Credentials credentials, final boolean needToHash) {
     this.credentials = credentials;
     this.publicKey = EthPublicKeyUtils.createPublicKey(credentials.getEcKeyPair().getPublicKey());
+    this.needToHash = needToHash;
+  }
+
+  public CredentialSigner(final Credentials credentials) {
+    this(credentials, true);
   }
 
   @Override
   public Signature sign(final byte[] data) {
-    final SignatureData signature = Sign.signMessage(data, credentials.getEcKeyPair());
+    final SignatureData signature = Sign.signMessage(data, credentials.getEcKeyPair(), needToHash);
     return new Signature(
         new BigInteger(signature.getV()),
         new BigInteger(1, signature.getR()),

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
@@ -9,8 +9,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 package tech.pegasys.signers.secp256k1.filebased;
 
@@ -18,6 +16,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigInteger;
+
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.ECKeyPair;
@@ -34,9 +33,9 @@ class CredentialSignerTest {
 
     final byte[] data = "Hello World".getBytes(UTF_8);
 
-    assertThat(hashingSigner.getPublicKey().getEncoded()).isEqualTo(nonHashingSigner.getPublicKey().getEncoded());
-    assertThat(hashingSigner.sign(data)).isEqualToComparingFieldByField(nonHashingSigner.sign(Hash.sha3(data)));
+    assertThat(hashingSigner.getPublicKey().getEncoded())
+        .isEqualTo(nonHashingSigner.getPublicKey().getEncoded());
+    assertThat(hashingSigner.sign(data))
+        .isEqualToComparingFieldByField(nonHashingSigner.sign(Hash.sha3(data)));
   }
-
-
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.signers.secp256k1.filebased;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Hash;
+
+class CredentialSignerTest {
+
+  @Test
+  void needToHashFlagAffectsProducedSignature() {
+    final Credentials credentials = Credentials.create(ECKeyPair.create(BigInteger.ONE));
+
+    final CredentialSigner hashingSigner = new CredentialSigner(credentials);
+    final CredentialSigner nonHashingSigner = new CredentialSigner(credentials, false);
+
+    final byte[] data = "Hello World".getBytes(UTF_8);
+
+    assertThat(hashingSigner.getPublicKey().getEncoded()).isEqualTo(nonHashingSigner.getPublicKey().getEncoded());
+    assertThat(hashingSigner.sign(data)).isEqualToComparingFieldByField(nonHashingSigner.sign(Hash.sha3(data)));
+  }
+
+
+}


### PR DESCRIPTION
The CredentialSigner uses the underlying web3j implementation to perform signing - at the moment, web3j will always hash the supplied data prior to producing a signature.

This update allows the CredentialSigner to be created  with or without enabling said hashing - this in turn means users of the class can supply a pre-hashed data object for signing.