### PR TITLE
Signer verify

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyAzureTransactionSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyAzureTransactionSignerAcceptanceTest.java
@@ -45,6 +45,18 @@ public class MultiKeyAzureTransactionSignerAcceptanceTest
         keyVaultName,
         tenantId);
     setup(tomlDirectory);
-    verifySignature();
+    validateSignature();
+  }
+
+  @Test
+  public void azureLoadedFromMultiKeyCanVerify(@TempDir Path tomlDirectory) {
+    createAzureTomlFileAt(
+        tomlDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".toml"),
+        clientId,
+        clientSecret,
+        keyVaultName,
+        tenantId);
+    setup(tomlDirectory);
+    validateVerify();
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyFileBasedTransactionSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyFileBasedTransactionSignerAcceptanceTest.java
@@ -45,6 +45,23 @@ public class MultiKeyFileBasedTransactionSignerAcceptanceTest
         tomlDirectory.resolve(FILENAME + ".toml"), keyPath, passwordPath.toString());
 
     setup(tomlDirectory);
-    verifySignature();
+    validateSignature();
+  }
+
+  @Test
+  public void fileBasedMultiKeyCanVerify(@TempDir Path tomlDirectory)
+      throws URISyntaxException, IOException {
+    final String keyPath =
+        new File(Resources.getResource("secp256k1/rich_benefactor_one.json").toURI())
+            .getAbsolutePath();
+
+    final Path passwordPath = tomlDirectory.resolve("password");
+    Files.write(passwordPath, "pass".getBytes(UTF_8));
+
+    createFileBasedTomlFileAt(
+        tomlDirectory.resolve(FILENAME + ".toml"), keyPath, passwordPath.toString());
+
+    setup(tomlDirectory);
+    validateVerify();
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyHashicorpTransactionSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyHashicorpTransactionSignerAcceptanceTest.java
@@ -43,7 +43,16 @@ public class MultiKeyHashicorpTransactionSignerAcceptanceTest
     createHashicorpTomlFileAt(tomlDirectory.resolve(FILENAME + ".toml"), hashicorpNode);
 
     setup(tomlDirectory);
-    verifySignature();
+    validateSignature();
+  }
+
+  @Test
+  void hashicorpLoadedFromMultiKeyCanVerify(@TempDir Path tomlDirectory) {
+
+    createHashicorpTomlFileAt(tomlDirectory.resolve(FILENAME + ".toml"), hashicorpNode);
+
+    setup(tomlDirectory);
+    validateVerify();
   }
 
   @AfterAll

--- a/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyTransactionSigningAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/signers/secp256k1/tests/multikey/signing/MultiKeyTransactionSigningAcceptanceTestBase.java
@@ -44,7 +44,7 @@ public class MultiKeyTransactionSigningAcceptanceTestBase extends MultiKeyAccept
   public static final ECPublicKey pubKey =
       EthPublicKeyUtils.createPublicKey(Bytes.fromHexString(PUBLIC_KEY_HEX_STRING));
 
-  void verifySignature() {
+  void validateSignature() {
     final Optional<Signer> signer = signerProvider.getSigner(pubKey);
     assertThat(signer).isNotEmpty();
 
@@ -58,6 +58,15 @@ public class MultiKeyTransactionSigningAcceptanceTestBase extends MultiKeyAccept
 
     final ECDSASignature ecdsaSignature = new ECDSASignature(signature.getR(), signature.getS());
     assertThat(ecdsaSignature.isCanonical()).isTrue();
+  }
+
+  void validateVerify() {
+    final Optional<Signer> signer = signerProvider.getSigner(pubKey);
+    assertThat(signer).isNotEmpty();
+
+    final Signature signature = signer.get().sign(DATA_TO_SIGN);
+
+    assertThat(signer.get().verify(DATA_TO_SIGN, signature)).isTrue();
   }
 
   private BigInteger recoverPublicKey(final Signature signature) {

--- a/signing/secp256k1/api/src/main/java/tech/pegasys/signers/secp256k1/api/Signer.java
+++ b/signing/secp256k1/api/src/main/java/tech/pegasys/signers/secp256k1/api/Signer.java
@@ -18,5 +18,7 @@ public interface Signer {
 
   Signature sign(final byte[] data);
 
+  boolean verify(final byte[] data, final Signature signature);
+
   ECPublicKey getPublicKey();
 }

--- a/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/secp256k1/impl/src/main/java/tech/pegasys/signers/secp256k1/azure/AzureKeyVaultSigner.java
@@ -99,6 +99,11 @@ public class AzureKeyVaultSigner implements Signer {
   }
 
   @Override
+  public boolean verify(final byte[] data, final Signature signature) {
+    return false;
+  }
+
+  @Override
   public ECPublicKey getPublicKey() {
     return publicKey;
   }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
@@ -15,14 +15,19 @@ package tech.pegasys.signers.secp256k1.filebased;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import tech.pegasys.signers.secp256k1.api.Signature;
+
 import java.math.BigInteger;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Hash;
 
 class CredentialSignerTest {
+  private static final String SECP_PRIVATE_KEY =
+      "c85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4";
 
   @Test
   void needToHashFlagAffectsProducedSignature() {
@@ -37,5 +42,17 @@ class CredentialSignerTest {
         .isEqualTo(nonHashingSigner.getPublicKey().getEncoded());
     assertThat(hashingSigner.sign(data))
         .isEqualToComparingFieldByField(nonHashingSigner.sign(Hash.sha3(data)));
+  }
+
+  @Test
+  void verifiesDataWasSignedBySignersPublicKey() {
+    final ECKeyPair ecKeyPair =
+        ECKeyPair.create(Bytes.fromHexString(SECP_PRIVATE_KEY).toArrayUnsafe());
+    final Credentials credentials = Credentials.create(ecKeyPair);
+    final CredentialSigner signer = new CredentialSigner(credentials);
+
+    final Bytes data = Bytes.wrap("This is an example of a signed message.".getBytes(UTF_8));
+    final Signature signature = signer.sign(data.toArray());
+    assertThat(signer.verify(data.toArray(), signature)).isTrue();
   }
 }

--- a/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/secp256k1/impl/src/test/java/tech/pegasys/signers/secp256k1/filebased/CredentialSignerTest.java
@@ -56,5 +56,17 @@ class CredentialSignerTest {
     assertThat(signer.verify(data.toArray(), signature)).isTrue();
   }
 
-  // TODO verify without hashing
+  @Test
+  void verifiesDataWithoutHashingWasSignedBySignersPublicKey() {
+    final ECKeyPair ecKeyPair =
+        ECKeyPair.create(Bytes.fromHexString(SECP_PRIVATE_KEY).toArrayUnsafe());
+    final Credentials credentials = Credentials.create(ecKeyPair);
+    final CredentialSigner signer = new CredentialSigner(credentials, false);
+
+    final Bytes data = Bytes.wrap("This is an example of a signed message.".getBytes(UTF_8));
+    final Bytes hashedData = Bytes.wrap(Hash.sha3(data.toArrayUnsafe()));
+
+    final Signature signature = signer.sign(hashedData.toArray());
+    assertThat(signer.verify(hashedData.toArray(), signature)).isTrue();
+  }
 }


### PR DESCRIPTION
Add verify operation to Signer. This has been implemented for both the CredentialSigner and the AzureKeyVaultSigner. This operation is needed for new API that is being added to Eth2Signer.