### PR TITLE
Implement unicode password support from EIP2335

### DIFF
--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/PasswordUtils.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/PasswordUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signers.bls.keystore;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.text.Normalizer;
+import java.text.Normalizer.Form;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class PasswordUtils {
+
+  public static Bytes normalizePassword(final String password) {
+    final String normalizedPassword = Normalizer.normalize(password, Form.NFKD);
+    final int[] filteredCodepoints =
+        normalizedPassword.chars().filter(c -> !isControlCode(c)).toArray();
+    final byte[] utf8Password =
+        new String(filteredCodepoints, 0, filteredCodepoints.length).getBytes(UTF_8);
+    return Bytes.wrap(utf8Password);
+  }
+
+  private static boolean isControlCode(final int c) {
+    return (0x00 <= c && c <= 0x1F) || (0x80 <= c && c <= 0x9F) || c == 0x7F;
+  }
+}

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/PasswordUtils.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/PasswordUtils.java
@@ -31,6 +31,14 @@ public class PasswordUtils {
   }
 
   private static boolean isControlCode(final int c) {
-    return (0x00 <= c && c <= 0x1F) || (0x80 <= c && c <= 0x9F) || c == 0x7F;
+    return isC0(c) || isC1(c) || c == 0x7F;
+  }
+
+  private static boolean isC1(final int c) {
+    return 0x80 <= c && c <= 0x9F;
+  }
+
+  private static boolean isC0(final int c) {
+    return 0x00 <= c && c <= 0x1F;
   }
 }

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KdfParam.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/KdfParam.java
@@ -15,6 +15,7 @@ package tech.pegasys.signers.bls.keystore.model;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
+import tech.pegasys.signers.bls.keystore.PasswordUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -36,7 +37,11 @@ public abstract class KdfParam {
 
   public abstract KdfFunction getKdfFunction();
 
-  public abstract Bytes generateDecryptionKey(final String password);
+  public Bytes generateDecryptionKey(final String password) {
+    return generateDecryptionKey(PasswordUtils.normalizePassword(password));
+  }
+
+  protected abstract Bytes generateDecryptionKey(final Bytes password);
 
   public void validate() {
     checkNotNull(getSalt(), "salt cannot be null");

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/Pbkdf2Param.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/Pbkdf2Param.java
@@ -16,8 +16,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 
-import java.nio.charset.StandardCharsets;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -76,11 +74,11 @@ public class Pbkdf2Param extends KdfParam {
   }
 
   @Override
-  public Bytes generateDecryptionKey(final String password) {
+  protected Bytes generateDecryptionKey(final Bytes password) {
     checkNotNull(password, "Password cannot be null");
     final PKCS5S2ParametersGenerator gen =
         new PKCS5S2ParametersGenerator(DigestFactory.createSHA256());
-    gen.init(password.getBytes(StandardCharsets.UTF_8), getSalt().toArrayUnsafe(), c);
+    gen.init(password.toArrayUnsafe(), getSalt().toArrayUnsafe(), c);
     final int keySizeInBits = getDkLen() * 8;
     final byte[] key = ((KeyParameter) gen.generateDerivedParameters(keySizeInBits)).getKey();
     return Bytes.wrap(key);

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/SCryptParam.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/SCryptParam.java
@@ -13,9 +13,6 @@
 package tech.pegasys.signers.bls.keystore.model;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -23,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.crypto.generators.SCrypt;
+import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 
 public class SCryptParam extends KdfParam {
   private final int n;
@@ -107,11 +105,11 @@ public class SCryptParam extends KdfParam {
   }
 
   @Override
-  public Bytes generateDecryptionKey(final String password) {
+  protected Bytes generateDecryptionKey(final Bytes password) {
     checkNotNull(password, "Password cannot be null");
     return Bytes.wrap(
         SCrypt.generate(
-            password.getBytes(UTF_8),
+            password.toArrayUnsafe(),
             getSalt().toArrayUnsafe(),
             getN(),
             getR(),

--- a/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/SCryptParam.java
+++ b/bls-keystore/src/main/java/tech/pegasys/signers/bls/keystore/model/SCryptParam.java
@@ -14,13 +14,14 @@ package tech.pegasys.signers.bls.keystore.model;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes;
 import org.bouncycastle.crypto.generators.SCrypt;
-import tech.pegasys.signers.bls.keystore.KeyStoreValidationException;
 
 public class SCryptParam extends KdfParam {
   private final int n;

--- a/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
+++ b/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
@@ -16,13 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import tech.pegasys.signers.bls.keystore.model.Cipher;
-import tech.pegasys.signers.bls.keystore.model.KdfParam;
-import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
-import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
-import tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction;
-import tech.pegasys.signers.bls.keystore.model.SCryptParam;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,6 +29,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tech.pegasys.signers.bls.keystore.model.Cipher;
+import tech.pegasys.signers.bls.keystore.model.KdfParam;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
+import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
+import tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction;
+import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 
 class KeyStoreTest {
   private static final int DKLEN = 32;
@@ -44,7 +43,8 @@ class KeyStoreTest {
   private static final int PARALLELIZATION = 1;
   private static final int BLOCKSIZE = 8;
 
-  private static final String PASSWORD = "testpassword";
+  private static final String PASSWORD =
+      "\uD835\uDD31\uD835\uDD22\uD835\uDD30\uD835\uDD31\uD835\uDD2D\uD835\uDD1E\uD835\uDD30\uD835\uDD30\uD835\uDD34\uD835\uDD2C\uD835\uDD2F\uD835\uDD21\uD83D\uDD11";
   private static final Bytes BLS_PRIVATE_KEY =
       Bytes.fromHexString("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
   private static final Bytes BLS_PUB_KEY =
@@ -75,14 +75,14 @@ class KeyStoreTest {
     return Stream.of(
         Arguments.of(
             new SCryptParam(DKLEN, MEMORY_CPU_COST, PARALLELIZATION, BLOCKSIZE, SALT),
-            Bytes.fromHexString("149aafa27b041f3523c53d7acba1905fa6b1c90f9fef137568101f44b531a3cb"),
+            Bytes.fromHexString("d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"),
             Bytes.fromHexString(
-                "54ecc8863c0550351eee5720f3be6a5d4a016025aa91cd6436cfec938d6a8d30")),
+                "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f")),
         Arguments.of(
             new Pbkdf2Param(DKLEN, ITERATIVE_COUNT, Pbkdf2PseudoRandomFunction.HMAC_SHA256, SALT),
-            Bytes.fromHexString("18b148af8e52920318084560fd766f9d09587b4915258dec0676cba5b0da09d8"),
+            Bytes.fromHexString("8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"),
             Bytes.fromHexString(
-                "a9249e0ca7315836356e4c7440361ff22b9fe71e2e2ed34fc1eb03976924ed48")));
+                "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad")));
   }
 
   @Test

--- a/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
+++ b/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/KeyStoreTest.java
@@ -16,6 +16,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import tech.pegasys.signers.bls.keystore.model.Cipher;
+import tech.pegasys.signers.bls.keystore.model.KdfParam;
+import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
+import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
+import tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction;
+import tech.pegasys.signers.bls.keystore.model.SCryptParam;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,12 +36,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import tech.pegasys.signers.bls.keystore.model.Cipher;
-import tech.pegasys.signers.bls.keystore.model.KdfParam;
-import tech.pegasys.signers.bls.keystore.model.KeyStoreData;
-import tech.pegasys.signers.bls.keystore.model.Pbkdf2Param;
-import tech.pegasys.signers.bls.keystore.model.Pbkdf2PseudoRandomFunction;
-import tech.pegasys.signers.bls.keystore.model.SCryptParam;
 
 class KeyStoreTest {
   private static final int DKLEN = 32;

--- a/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/PasswordUtilsTest.java
+++ b/bls-keystore/src/test/java/tech/pegasys/signers/bls/keystore/PasswordUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.signers.bls.keystore;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.pegasys.signers.bls.keystore.PasswordUtils.normalizePassword;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class PasswordUtilsTest {
+  @Test
+  void shouldLeaveSimplePasswordUnchanged() {
+    assertThat(normalizePassword("testpassword")).isEqualTo(utf8("testpassword"));
+  }
+
+  @Test
+  void shouldStripControlCharactersFromPassword() {
+    assertThat(normalizePassword("\u0000\u001F\u0080\u009Ftest \n\f\tpass\u007Fword\n"))
+        .isEqualTo(utf8("test password"));
+  }
+
+  @Test
+  void shouldDecodePasswordFromEip2335() {
+    final String password =
+        "\uD835\uDD31\uD835\uDD22\uD835\uDD30\uD835\uDD31\uD835\uDD2D\uD835\uDD1E\uD835\uDD30\uD835\uDD30\uD835\uDD34\uD835\uDD2C\uD835\uDD2F\uD835\uDD21\uD83D\uDD11";
+    assertThat(normalizePassword(password))
+        .isEqualTo(Bytes.fromHexString("0x7465737470617373776f7264f09f9491"));
+  }
+
+  private Bytes utf8(final String password) {
+    return Bytes.wrap(password.getBytes(UTF_8));
+  }
+}

--- a/bls-keystore/src/test/resources/pbkdf2TestVector.json
+++ b/bls-keystore/src/test/resources/pbkdf2TestVector.json
@@ -13,16 +13,17 @@
     "checksum": {
       "function": "sha256",
       "params": {},
-      "message": "18b148af8e52920318084560fd766f9d09587b4915258dec0676cba5b0da09d8"
+      "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
     },
     "cipher": {
       "function": "aes-128-ctr",
       "params": {
         "iv": "264daa3f303d7259501c93d997d84fe6"
       },
-      "message": "a9249e0ca7315836356e4c7440361ff22b9fe71e2e2ed34fc1eb03976924ed48"
+      "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
     }
   },
+  "description": "This is a test keystore that uses PBKDF2 to secure the secret.",
   "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
   "path": "m/12381/60/0/0",
   "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",

--- a/bls-keystore/src/test/resources/scryptExtraFieldTestVector.json
+++ b/bls-keystore/src/test/resources/scryptExtraFieldTestVector.json
@@ -14,14 +14,14 @@
     "checksum": {
       "function": "sha256",
       "params": {},
-      "message": "149aafa27b041f3523c53d7acba1905fa6b1c90f9fef137568101f44b531a3cb"
+      "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
     },
     "cipher": {
       "function": "aes-128-ctr",
       "params": {
         "iv": "264daa3f303d7259501c93d997d84fe6"
       },
-      "message": "54ecc8863c0550351eee5720f3be6a5d4a016025aa91cd6436cfec938d6a8d30"
+      "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
     }
   },
   "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",

--- a/bls-keystore/src/test/resources/scryptTestVector.json
+++ b/bls-keystore/src/test/resources/scryptTestVector.json
@@ -14,16 +14,17 @@
     "checksum": {
       "function": "sha256",
       "params": {},
-      "message": "149aafa27b041f3523c53d7acba1905fa6b1c90f9fef137568101f44b531a3cb"
+      "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
     },
     "cipher": {
       "function": "aes-128-ctr",
       "params": {
         "iv": "264daa3f303d7259501c93d997d84fe6"
       },
-      "message": "54ecc8863c0550351eee5720f3be6a5d4a016025aa91cd6436cfec938d6a8d30"
+      "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
     }
   },
+  "description": "This is a test keystore that uses scrypt to secure the secret.",
   "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
   "path": "m/12381/60/3141592653/589793238",
   "uuid": "1d85ae20-35c5-4611-98e8-aa14a633906f",


### PR DESCRIPTION
EIP2335 has been updated to explicitly make passwords unicode and specify how to normalise them.  This implements that for signers.  Note that because control characters are now stripped from passwords as part of normalisation, there is no need for callers to strip line endings when reading files and the should just read the entire file content.

See https://github.com/ethereum/EIPs/pull/2749/files for spec changes.